### PR TITLE
Fix wrong method name in debug code

### DIFF
--- a/NWaves.DemoForms/FiltersForm.cs
+++ b/NWaves.DemoForms/FiltersForm.cs
@@ -830,8 +830,8 @@ namespace NWaves.DemoForms
 
             _filter.Reset();
 
-            _filteredSignal = _filter.ProcessChunks(_signal);
-            //_filteredSignal = _filter.ProcessChunks(_signal, method: FilteringMethod.OverlapAdd);
+            _filteredSignal = _filter.ApplyTo(_signal);
+            //_filteredSignal = _filter.ApplyTo(_signal, method: FilteringMethod.OverlapAdd);
             signalAfterFilteringPanel.Signal = _filteredSignal;
             spectrogramAfterFilteringPanel.Spectrogram = _stft.Spectrogram(_filteredSignal);
 #endif


### PR DESCRIPTION
Hi. Not sure what this debug code does but it stops the project from compiling. My best guess is that `ProcessChunks()` was renamed at some point to `ApplyTo()`. Here's a fix.