### PR TITLE
Fixed: Pressing record twice disables stop button

### DIFF
--- a/NWaves.DemoMfccOnline/Services/AudioService.cs
+++ b/NWaves.DemoMfccOnline/Services/AudioService.cs
@@ -140,6 +140,9 @@ namespace NWaves.DemoMfccOnline.Services
 
         public void StartRecording(int deviceNumber = 0)
         {
+            _recorder?.StopRecording();
+            _recorder?.Dispose();
+
             _recorder = new WaveIn
             {
                 WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(16000, 1),


### PR DESCRIPTION
Another minor bug fix. If you press Record twice in the DemoMfccOnline app you get two recordings going at the same time. The "stop" button will only stop the most recent one. This patch forces the recording to stop before starting another.